### PR TITLE
Disable test Button_Press_Enter_Fires_OnClickAsync

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
@@ -311,10 +311,7 @@ public class ButtonTests : ControlTestBase
         });
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/11327")]
     [WinFormsFact]
-    [SkipOnArchitecture(TestArchitectures.X64,
-       "Flaky tests, see: https://github.com/dotnet/winforms/issues/11327")]
     public async Task Button_PerformClick_Fires_OnClickAsync()
     {
         await RunTestAsync((form, button) =>
@@ -330,7 +327,10 @@ public class ButtonTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11327")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+       "Flaky tests, see: https://github.com/dotnet/winforms/issues/11327")]
     public async Task Button_Press_Enter_Fires_OnClickAsync()
     {
         await RunTestAsync(async (form, button) =>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- Disable unstable test case `Button_Press_Enter_Fires_OnClickAsync`